### PR TITLE
Set audio range max value to duration

### DIFF
--- a/src/components/ReactAudioPlayer/ReactAudioPlayerInner.js
+++ b/src/components/ReactAudioPlayer/ReactAudioPlayerInner.js
@@ -136,6 +136,7 @@ const ReactAudioPlayerInner = (props) => {
                     ref={progressBarRef}
                     onChange={changePlayerCurrentTime}
                     aria-label="Audio progress"
+                    max={duration}
                   />
                 </div>
                 <div className='player-times'>


### PR DESCRIPTION
This fixes it so that the bar shows the full duration and not 1:40 (100 seconds). The problem was that range inputs have a default max value of 100.
![image](https://github.com/APMG/apm-react-audio-player/assets/33332959/bfd9e53e-011e-4412-8892-8fb7b2a51a8c)
