### PR TITLE
Fix glitch that prevents progress bar from updating on first play

### DIFF
--- a/src/hooks/useReactAudioPlayer.js
+++ b/src/hooks/useReactAudioPlayer.js
@@ -7,8 +7,7 @@ export const useAudioPlayer = (audioRef, progressBarRef, volumeCtrl) => {
   const [isFinishedPlaying, setIsFinishedPlaying] = useState(false)
   const animationRef = useRef() // reference the animation
   const [isMuted, setIsMuted] = useState(false)
-  const isStream =
-    audioRef.current && audioRef.current.currentSrc.includes('stream')
+  const [isStream, setIsStream] = useState(false)
 
   useEffect(() => {
     if (currentTime === Number(duration)) {
@@ -20,6 +19,7 @@ export const useAudioPlayer = (audioRef, progressBarRef, volumeCtrl) => {
   const onLoadedMetadata = () => {
     const seconds = Math.floor(audioRef.current.duration)
     setDuration(seconds)
+    setIsStream(audioRef.current && audioRef.current.currentSrc.includes('stream'))
 
     if (!isStream) {
       progressBarRef.current.max = seconds


### PR DESCRIPTION
I should note that I've been getting the error "TypeError: progressBarRef.current is undefined" when I refresh sometimes, but I think that isn't caused by this since I also got it sometimes after undoing this.